### PR TITLE
Update VM sizes and FTDv versions in ARM template

### DIFF
--- a/autoscale/azure/ARM Template/azure_ftdv_autoscale.json
+++ b/autoscale/azure/ARM Template/azure_ftdv_autoscale.json
@@ -97,7 +97,7 @@
       },
       "softwareVersion": {
         "type": "string",
-        "defaultValue": "67065.0.0",
+        "defaultValue": "72082.0.0",
         "allowedValues": [
             "72082.0.0",
             "71092.0.0",

--- a/autoscale/azure/ARM Template/azure_ftdv_autoscale.json
+++ b/autoscale/azure/ARM Template/azure_ftdv_autoscale.json
@@ -99,8 +99,10 @@
         "type": "string",
         "defaultValue": "67065.0.0",
         "allowedValues": [
-            "67065.0.0",
-            "66459.0.0",
+            "72082.0.0",
+            "71092.0.0",
+            "70288.0.0",
+            "66581.0.0",
             "640110.0.0"
         ],
         "metadata": {
@@ -114,7 +116,11 @@
             "Standard_D3",
             "Standard_D3_v2",
             "Standard_D4_v2",
-            "Standard_D5_v2"
+            "Standard_D5_v2",
+            "Standard_D8s_v3",
+            "Standard_D16s_v3",
+            "Standard_F8s_v2",
+            "Standard_F16s_v2"
         ],
         "metadata" : {
             "description" : "Size of the Virtual Machine"


### PR DESCRIPTION
VM sizes have been updated as of the latest FTDv version (detailed at https://www.cisco.com/c/en/us/td/docs/security/firepower/quick_start/consolidated_ftdv_gsg/ftdv-gsg/m-ftdv-azure-gsg.html). 

FTDv versions for the marketplace image have also been updated and are as follows:

72082.0.0
71092.0.0
70288.0.0
66581.0.0
640110.0.0